### PR TITLE
Fix weird GC issue

### DIFF
--- a/raptor_db.nim
+++ b/raptor_db.nim
@@ -160,10 +160,12 @@ type
 proc sscanf(s: cstring, frmt: cstring): cint {.varargs, importc,
         header: "<stdio.h>".}
 
-proc strlen(s: cstring): cint {.importc: "strlen", nodecl.}
+proc strlen(s: cstring): csize {.importc: "strlen", nodecl.}
+# proc strlen(s: ptr char): csize {.importc: "strlen", nodecl.}
 
 proc strlen(a: var Headroom): int =
     echo "  calc strlen"
+    echo addr(a) # Changes the stacktrace to load_rbd(205), newObjNoInit
     let n = strlen(cast[cstring](addr a))
     echo "  calc'd:", n
     return n
@@ -176,9 +178,9 @@ proc toString(ins: var Headroom, outs: var string) =
         #echo i, ":", ins[i]
         outs[i] = ins[i]
 
-proc load_rdb*(sin: streams.Stream): ref Db =
+proc load_rdb*(sin: streams.Stream): Db = # ref Db
     stderr.write("BEFORE")
-    new(result)
+    # new(result)
     echo " version init:", result.version
     stderr.write("AFTER")
     #newSeq(result.seqs, 0)


### PR DESCRIPTION
This fixes the your issue.

Debugging process:

My log were different from the one you reported on the forum (I also used GcAssert)
```
[GCASSERT] decRef: waZctDecRefTraceback (most recent call last)
/home/beta/Programming/scratchspace/nim-help/t_raptor_db.nim(246) t_raptor_db
/home/beta/Programming/scratchspace/nim-help/t_raptor_db.nim(220) main
/home/beta/Programming/scratchspace/nim-help/raptor_db.nim(271) get_length_cutoff
/home/beta/Programming/scratchspace/nim-help/raptor_db.nim(227) load_rdb
/home/beta/Programming/scratchspace/nim-help/raptor_db.nim(168) strlen
/home/beta/.choosenim/toolchains/nim-#devel/lib/system/strmantle.nim(74) nimIntToStr
/home/beta/.choosenim/toolchains/nim-#devel/lib/system/gc.nim(439) newObj
```

I looked into strlen to check if there wasn't an issue in its usage as it's easy to misuse.
I added an `echo addr(a)` to check the address and the error changed completely to

```
GCASSERT] decRef: waZctDecRefTraceback (most recent call last)
/home/beta/Programming/scratchspace/nim-help/t_raptor_db.nim(246) t_raptor_db
/home/beta/Programming/scratchspace/nim-help/t_raptor_db.nim(196) main
/home/beta/Programming/scratchspace/nim-help/raptor_db.nim(273) get_length_cutoff
/home/beta/Programming/scratchspace/nim-help/raptor_db.nim(205) load_rdb
/home/beta/.choosenim/toolchains/nim-#devel/lib/system/gc.nim(435) newObjNoInit
```

I looked into the C code into what called newObjNoInit, found that it was creating a new string.

But in general a new string even uninitialized works fine in Nim. Looking back into the code,
the only unusual thing related to GC was returning a `ref Db` (instead of having a `type DbRef = ref Db` alias) so I tried to remove that and code compiled and ran successfully.